### PR TITLE
set_font in vte

### DIFF
--- a/vanilla_installer/gtk/progress.ui
+++ b/vanilla_installer/gtk/progress.ui
@@ -46,11 +46,13 @@
                     <object class="GtkBox" id="console_output">
                         <property name="visible">True</property>
                         <property name="margin-top">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="orientation">vertical</property>
                     </object>
                 </child>
                 <style>
-                    <class name="vte-console"/>
+                    <class name="card"/>
                 </style>
             </object>
         </child>

--- a/vanilla_installer/main.py
+++ b/vanilla_installer/main.py
@@ -53,10 +53,6 @@ class FirstSetupApplication(Adw.Application):
         CSS inspired by: Sonny Piers <https://github.com/sonnyp>
         """
         css = """
-.vte-console {
-    background-color: #000000;
-    border-radius: 12px;
-}
 .theme-selector {
     border-radius: 100px;
     margin: 8px;

--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -82,17 +82,14 @@ class VanillaProgress(Gtk.Box):
         self.colors = [Gdk.RGBA() for c in palette]
         [color.parse(s) for (color, s) in zip(self.colors, palette)]
         desktop_schema = Gio.Settings.new('org.gnome.desktop.interface')
-        
         if desktop_schema.get_enum('color-scheme') == 0:
             self.fg.parse(FOREGROUND)
             self.bg.parse(BACKGROUND)
-            self.__terminal.set_colors(self.fg, self.bg, self.colors)
-        
         elif desktop_schema.get_enum('color-scheme') == 1:
             self.fg.parse(FOREGROUND_DARK)
             self.bg.parse(BACKGROUND_DARK)
-            self.__terminal.set_colors(self.fg, self.bg, self.colors)
-
+        self.__terminal.set_colors(self.fg, self.bg, self.colors)
+        
         for _, tour in self.__tour.items():
             self.carousel_tour.append(VanillaTour(self.__window, tour))
 

--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -1,7 +1,6 @@
 # progress.py
 #
 # Copyright 2022 mirkobrombin
-# Copyright 2022 muqtadir
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-from gi.repository import Gtk, GLib, Adw, Vte, Pango
+from gi.repository import Gtk, Gdk, Gio, GLib, Adw, Vte, Pango
 
 from vanilla_installer.utils.run_async import RunAsync
 
@@ -34,8 +33,7 @@ class VanillaProgress(Gtk.Box):
     console_button = Gtk.Template.Child()
     console_box = Gtk.Template.Child()
     console_output = Gtk.Template.Child()
-
-
+    
     def __init__(self, window, tour: dict, **kwargs):
         super().__init__(**kwargs)
         self.__window = window
@@ -70,6 +68,30 @@ class VanillaProgress(Gtk.Box):
         self.__terminal.set_mouse_autohide(True)
         self.console_output.append(self.__terminal)
         self.__terminal.connect("child-exited", self.on_vte_child_exited)
+        
+        palette = ["#353535", "#c01c28", "#26a269", "#a2734c", "#12488b", "#a347ba", "#2aa1b3", "#cfcfcf", "#5d5d5d", "#f66151", "#33d17a", "#e9ad0c", "#2a7bde", "#c061cb", "#33c7de", "#ffffff"]
+        
+        FOREGROUND = palette[0]
+        BACKGROUND = palette[15]
+        FOREGROUND_DARK = palette[15]
+        BACKGROUND_DARK = palette[0]
+        
+        self.fg = Gdk.RGBA()
+        self.bg = Gdk.RGBA()
+
+        self.colors = [Gdk.RGBA() for c in palette]
+        [color.parse(s) for (color, s) in zip(self.colors, palette)]
+        desktop_schema = Gio.Settings.new('org.gnome.desktop.interface')
+        
+        if desktop_schema.get_enum('color-scheme') == 0:
+            self.fg.parse(FOREGROUND)
+            self.bg.parse(BACKGROUND)
+            self.__terminal.set_colors(self.fg, self.bg, self.colors)
+        
+        elif desktop_schema.get_enum('color-scheme') == 1:
+            self.fg.parse(FOREGROUND_DARK)
+            self.bg.parse(BACKGROUND_DARK)
+            self.__terminal.set_colors(self.fg, self.bg, self.colors)
 
         for _, tour in self.__tour.items():
             self.carousel_tour.append(VanillaTour(self.__window, tour))

--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -1,6 +1,7 @@
 # progress.py
 #
 # Copyright 2022 mirkobrombin
+# Copyright 2022 muqtadir
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-from gi.repository import Gtk, GLib, Adw, Vte
+from gi.repository import Gtk, GLib, Adw, Vte, Pango
 
 from vanilla_installer.utils.run_async import RunAsync
 
@@ -40,6 +41,11 @@ class VanillaProgress(Gtk.Box):
         self.__window = window
         self.__tour = tour    
         self.__terminal = Vte.Terminal()
+        self.__font = Pango.FontDescription()
+        self.__font.set_family("Ubuntu Mono")
+        self.__font.set_size(13 * Pango.SCALE)
+        self.__font.set_weight(Pango.Weight.NORMAL)
+        self.__font.set_stretch(Pango.Stretch.NORMAL)
 
         self.__build_ui()
 
@@ -60,6 +66,7 @@ class VanillaProgress(Gtk.Box):
 
     def __build_ui(self):
         self.__terminal.set_cursor_blink_mode(Vte.CursorBlinkMode.ON)
+        self.__terminal.set_font(self.__font)
         self.__terminal.set_mouse_autohide(True)
         self.console_output.append(self.__terminal)
         self.__terminal.connect("child-exited", self.on_vte_child_exited)


### PR DESCRIPTION
- atm, `Source Code Pro` fonts are not available in repos, so using `Ubuntu Mono` as placeholder Pango Font.
- get `color-scheme` to apply vte `bg` and `fg` colors

### screenshot:
| light | dark |
| ------ | ------ |
| ![Screenshot from 2022-11-19 18-44-29](https://user-images.githubusercontent.com/54065734/202866970-905855f0-e7be-44a5-bb32-6c4d8cce9d23.png) | ![Screenshot from 2022-11-19 18-46-36](https://user-images.githubusercontent.com/54065734/202866979-5a7946d2-f92e-4861-acbf-44e94a2e5305.png) |
