### PR TITLE
Correct timezone codes for Distinst

### DIFF
--- a/vanilla_installer/core/timezones.py
+++ b/vanilla_installer/core/timezones.py
@@ -14,11 +14,12 @@ cleanup_rules = [
 for timezone in GWeather.Location.get_world().get_timezones():
     _timezone = timezone.get_identifier()
 
-    if len(_timezone.split("/")) < 2:
+    _tz_splits = _timezone.split("/")
+    if len(_tz_splits) < 2:
         continue
 
-    _country = _timezone.split('/')[0]
-    _city = _timezone[_country.__len__()+1:]
+    _country = _tz_splits[0]
+    _city = _tz_splits[-1]
 
     if _country.lower() in cleanup_rules:
         continue
@@ -41,10 +42,9 @@ def get_current_timezone():
     city = timezone[country.__len__()+1:]
 
     return country, city
-    
+
 def get_preview_timezone(country, city):
     timezone = pytz.timezone(f"{country}/{city}")
     now = datetime.datetime.now(timezone)
 
     return now.strftime("%H:%M"), now.strftime("%A, %d %B %Y")
-


### PR DESCRIPTION
Distinst doesn't recognize timezones with a country name between region and city, like `America/Argentina/Buenos_Aires`. Instead, it uses only region + city for all timezones. When Distinst cannot correctly parse a timezone, for some unbeknownst reason, it refuses to partition the disk, leading to an error during `post_install` on our end.

This shouldn't break the timezone patch from @mirkobrombin since `/usr/share/zoneinfo` already has links for these city names (e.g. `/usr/share/zoneinfo/America/Buenos_Aires` links to `/usr/share/zoneinfo/America/Argentina/Buenos_Aires`.