### PR TITLE
feat: add get_timezone_by_ip()

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - libgnome-desktop-4-dev
 - libgweather-4-dev
 - python3-tz
+- python3-requests
 
 ### Build
 ```bash

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Package: vanilla-installer
 Architecture: any
 Depends: python3,
          python3-tz,
+         python3-requests,
          python3-gi,
          libadwaita-1-0,
          libgnome-desktop-4-2,

--- a/vanilla_installer/core/timezones.py
+++ b/vanilla_installer/core/timezones.py
@@ -1,5 +1,6 @@
 import datetime
 import pytz
+import requests
 
 from gi.repository import GnomeDesktop, GWeather
 
@@ -35,13 +36,30 @@ for country in all_timezones.keys():
     all_timezones[country] = sorted(all_timezones[country])
 
 def get_current_timezone():
-    timezone = GnomeDesktop.WallClock().get_timezone()
-    timezone = timezone.get_identifier()
+    success_code, country, city = get_timezone_by_ip()
+    if not success_code:
+        timezone = GnomeDesktop.WallClock().get_timezone()
+        timezone = timezone.get_identifier()
 
-    country = timezone.split('/')[0]
-    city = timezone[country.__len__()+1:]
+        country = timezone.split('/')[0]
+        city = timezone[country.__len__()+1:]
 
     return country, city
+
+
+def get_timezone_by_ip():
+    try:
+        res = requests.get("http://ip-api.com/json", timeout=3).json()
+        timezone = res["timezone"]
+        country = timezone.split("/")[0]
+        city = timezone[country.__len__() + 1 :]
+        success_code = True
+    except:
+        success_code = False
+        city = -1
+        country = -1
+    return success_code, country, city
+
 
 def get_preview_timezone(country, city):
     timezone = pytz.timezone(f"{country}/{city}")


### PR DESCRIPTION
This function adds a request network interface, and tries to get the current time zone through the network interface. This requires the installer to have a network, and when there is no network, the original solution will be tried.

This may cause, in the worst case, the UI display is blocked for 3s