### PR TITLE
Restrict debian, vanillaos and vanilla-os usernames

### DIFF
--- a/vanilla_installer/defaults/users.py
+++ b/vanilla_installer/defaults/users.py
@@ -95,10 +95,10 @@ class VanillaDefaultUsers(Adw.Bin):
             _status = False
             self.__window.toast("Username cannot be empty. Please type a username.")
 
-        # cannot be root
-        elif _input == "root":
+        # cannot be root, ubuntu, vanillaos or vanilla-os
+        elif _input == "root" or _input == "vanillaos" or _input == "vanilla-os":
             _status = False
-            self.__window.toast("root user is reserved. Please choose another username.")
+            self.__window.toast("Username is reserved. Please choose another username.")
 
         if not _status:
             self.username_entry.add_css_class('error')

--- a/vanilla_installer/defaults/users.py
+++ b/vanilla_installer/defaults/users.py
@@ -95,8 +95,8 @@ class VanillaDefaultUsers(Adw.Bin):
             _status = False
             self.__window.toast("Username cannot be empty. Please type a username.")
 
-        # cannot be root, ubuntu, vanillaos or vanilla-os
-        elif _input == "root" or _input == "vanillaos" or _input == "vanilla-os":
+        # cannot be root, debian, vanillaos or vanilla-os
+        elif _input == "root" or _input == "vanillaos" or _input == "vanilla-os" or _input == 'debian':
             _status = False
             self.__window.toast("Username is reserved. Please choose another username.")
 


### PR DESCRIPTION
This pull request disallows users from using 'debian', 'vanillaos' or 'vanilla-os' as their username, as it could confuse First Setup (which checks the username to ensure it isn't being run in a live session).