### PR TITLE
Relaxes the username validation regexp

### DIFF
--- a/vanilla_installer/defaults/users.py
+++ b/vanilla_installer/defaults/users.py
@@ -86,7 +86,7 @@ class VanillaDefaultUsers(Adw.Bin):
             _input = self.username_entry.get_text()
             
         # cannot contain special characters
-        if re.search(r'[^a-z0-9]', _input):
+        if not re.fullmatch(r'[a-z_][a-z0-9_-]*[$]?', _input):
             _status = False
             self.__window.toast("Username cannot contain special characters or uppercase letters. Please choose another username.")
 


### PR DESCRIPTION
This commit updates the username validation regexp following the recommendations from the `useradd` man page.

This will have to be applied to first-setup too in order to close the issue https://github.com/Vanilla-OS/first-setup/issues/179.