### PR TITLE
Updates the VanillaProgress font to Cantarell

### DIFF
--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -41,7 +41,7 @@ class VanillaProgress(Gtk.Box):
         self.__tour = tour
         self.__terminal = Vte.Terminal()
         self.__font = Pango.FontDescription()
-        self.__font.set_family("Ubuntu Mono")
+        self.__font.set_family("Cantarell")
         self.__font.set_size(13 * Pango.SCALE)
         self.__font.set_weight(Pango.Weight.NORMAL)
         self.__font.set_stretch(Pango.Stretch.NORMAL)


### PR DESCRIPTION
Since https://github.com/Vanilla-OS/vanilla-base-desktop/pull/7 is merged, I have updated the progress installation terminal font to `Cantarell`.

Before with Ubuntu Mono:
![Screenshot from 2023-06-26 13-32-18](https://github.com/Vanilla-OS/vanilla-installer/assets/478564/f5bb17b4-0305-4bbe-a230-4f02542746a8)


Then with Cantarell:
![Screenshot from 2023-06-26 13-33-35](https://github.com/Vanilla-OS/vanilla-installer/assets/478564/55bc2d42-b7dc-4601-bdfe-c739000d512b)

Closes #165