### PR TITLE
feat:[close #220] Remove periods in the recovery because GNOME Hig does not like them

### DIFF
--- a/vanilla_installer/gtk/dialog-recovery.ui
+++ b/vanilla_installer/gtk/dialog-recovery.ui
@@ -24,7 +24,7 @@
                           <object class="AdwActionRow" id="row_console">
                             <property name="icon-name">utilities-terminal-symbolic</property>
                             <property name="title" translatable="yes">Console</property>
-                            <property name="subtitle" translatable="yes">Open a Terminal.</property>
+                            <property name="subtitle" translatable="yes">Open a Terminal</property>
                             <property name="activatable">true</property>
                             <child type="suffix">
                               <object class="GtkImage">
@@ -41,7 +41,7 @@
                           <object class="AdwActionRow" id="row_gparted">
                             <property name="icon-name">drive-harddisk-symbolic</property>
                             <property name="title" translatable="yes">Gparted</property>
-                            <property name="subtitle" translatable="yes">Manage disks and partitions.</property>
+                            <property name="subtitle" translatable="yes">Manage disks and partitions</property>
                             <property name="activatable">true</property>
                             <child type="suffix">
                               <object class="GtkImage">
@@ -58,7 +58,7 @@
                           <object class="AdwActionRow" id="row_handbook">
                             <property name="icon-name">help-browser-symbolic</property>
                             <property name="title" translatable="yes">Handbook</property>
-                            <property name="subtitle" translatable="yes">Read the Vanilla OS Handbook.</property>
+                            <property name="subtitle" translatable="yes">Read the Vanilla OS Handbook</property>
                             <property name="activatable">true</property>
                             <child type="suffix">
                               <object class="GtkImage">
@@ -75,7 +75,7 @@
                           <object class="AdwActionRow" id="row_web">
                             <property name="icon-name">web-browser-symbolic</property>
                             <property name="title" translatable="yes">Web Browser</property>
-                            <property name="subtitle" translatable="yes">Search online for help.</property>
+                            <property name="subtitle" translatable="yes">Search online for help</property>
                             <property name="activatable">true</property>
                             <child type="suffix">
                               <object class="GtkImage">


### PR DESCRIPTION
this rule does not makes sense btw