### PR TITLE
fix: Do not make signal names translatable

### DIFF
--- a/vanilla_installer/layouts/preferences.py
+++ b/vanilla_installer/layouts/preferences.py
@@ -39,7 +39,7 @@ class VanillaLayoutPreferences(Adw.Bin):
         self.__build_ui()
 
         # signals
-        self.btn_next.connect(_("clicked"), self.__next_step)
+        self.btn_next.connect("clicked", self.__next_step)
 
     def __build_ui(self):
         self.status_page.set_icon_name(self.__step["icon"])

--- a/vanilla_installer/views/confirm.py
+++ b/vanilla_installer/views/confirm.py
@@ -121,8 +121,8 @@ class VanillaConfirm(Adw.Bin):
         for widget in self.active_widgets:
             self.group_changes.add(widget)
 
-        self._btn_confirm_signal = self.btn_confirm.connect(_("clicked"), self.__on_confirm)
+        self._btn_confirm_signal = self.btn_confirm.connect("clicked", self.__on_confirm)
 
     def __on_confirm(self, widget):
-        self.emit(_("installation-confirmed"))
+        self.emit("installation-confirmed")
         self.btn_confirm.disconnect(self._btn_confirm_signal)

--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -48,8 +48,8 @@ class VanillaProgress(Gtk.Box):
 
         self.__build_ui()
 
-        self.tour_button.connect(_("clicked"), self.__on_tour_button)
-        self.console_button.connect(_("clicked"), self.__on_console_button)
+        self.tour_button.connect("clicked", self.__on_tour_button)
+        self.console_button.connect("clicked", self.__on_console_button)
 
     def __on_tour_button(self, *args):
         self.tour_box.set_visible(True)

--- a/vanilla_installer/windows/main_window.py
+++ b/vanilla_installer/windows/main_window.py
@@ -58,10 +58,10 @@ class VanillaWindow(Adw.ApplicationWindow):
         self.__connect_signals()
 
     def __connect_signals(self):
-        self.btn_back.connect(_("clicked"), self.back)
-        self.carousel.connect(_("page-changed"), self.__on_page_changed)
+        self.btn_back.connect("clicked", self.back)
+        self.carousel.connect("page-changed", self.__on_page_changed)
         self.__builder.widgets[-1].btn_next.connect("clicked", self.update_finals)
-        self.__view_confirm.connect(_("installation-confirmed"), self.on_installation_confirmed)
+        self.__view_confirm.connect("installation-confirmed", self.on_installation_confirmed)
 
     def __build_ui(self):
         if "VANILLA_FORCE_TOUR" not in os.environ:


### PR DESCRIPTION
If these strings are translated these signals would not be emitted/caught, so we shouldn't mark these strings translatable.