### PR TITLE
update the look of language/locale screen

### DIFF
--- a/vanilla_installer/defaults/language.py
+++ b/vanilla_installer/defaults/language.py
@@ -15,10 +15,31 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-
 from gi.repository import Adw, Gtk
-
+from gi.repository import GnomeDesktop
 from vanilla_installer.core.languages import all_languages, current_language
+
+@Gtk.Template(resource_path="/org/vanillaos/Installer/gtk/widget-language.ui")
+class LanguageRow(Adw.ActionRow):
+    __gtype_name__ = "LanguageRow"
+
+    select_button = Gtk.Template.Child()
+    suffix_bin = Gtk.Template.Child()
+
+    def __init__(self, title, subtitle, selected_language, **kwargs):
+        super().__init__(**kwargs)
+        self.__title = title
+        self.__subtitle = subtitle
+        self.__selected_language = selected_language
+
+        self.set_title(title)
+        self.suffix_bin.set_label(subtitle)
+
+        self.select_button.connect("toggled", self.__on_check_button_toggled)
+
+    def __on_check_button_toggled(self, widget):
+        self.__selected_language["language_title"] = self.__title
+        self.__selected_language["language_subtitle"] = self.__subtitle
 
 
 @Gtk.Template(resource_path="/org/vanillaos/Installer/gtk/default-language.ui")
@@ -26,11 +47,11 @@ class VanillaDefaultLanguage(Adw.Bin):
     __gtype_name__ = "VanillaDefaultLanguage"
 
     btn_next = Gtk.Template.Child()
-    combo_languages = Gtk.Template.Child()
-    str_list_languages = Gtk.Template.Child()
     entry_search_language = Gtk.Template.Child()
-
     search_controller = Gtk.EventControllerKey.new()
+    all_languages_group = Gtk.Template.Child()
+
+    selected_language = {'language_title': None, 'language_subtitle': None}
 
     def __init__(self, window, distro_info, key, step, **kwargs):
         super().__init__(**kwargs)
@@ -39,40 +60,41 @@ class VanillaDefaultLanguage(Adw.Bin):
         self.__key = key
         self.__step = step
 
-        # set up the string list for all the languages
-        for _, lang in all_languages.items():
-            self.str_list_languages.append(lang)
-
-        # set up current language
-        for locale in all_languages.keys():
-            if current_language == locale:
-                self.combo_languages.set_selected(
-                    list(all_languages.keys()).index(locale)
-                )
-                break
+        self.__language_rows = self.__generate_language_list_widgets(self.selected_language)
+        for i, widget in enumerate(self.__language_rows):
+            self.all_languages_group.append(widget)
 
         # signals
         self.btn_next.connect("clicked", self.__window.next)
-        self.search_controller.connect(
-            "key-released", self.__on_search_key_pressed)
+        self.search_controller.connect("key-released", self.__on_search_key_pressed)
         self.entry_search_language.add_controller(self.search_controller)
+
+    def __generate_language_list_widgets(self, selected_language):
+        language_widgets = []
+        curr_language = GnomeDesktop.get_language_from_locale(current_language, None)
+
+        for language_subtitle, language_title in all_languages.items():
+            language_row = LanguageRow(language_title, language_subtitle, selected_language)
+            
+            if len(language_widgets)>0:
+                language_row.select_button.set_group(language_widgets[0].select_button)
+            language_widgets.append(language_row)
+
+            if curr_language == language_title:
+                language_row.select_button.set_active(True)
+
+        return language_widgets
 
     def get_finals(self):
         return {
-            "language": list(all_languages.keys())[self.combo_languages.get_selected()]
+            "language": self.selected_language["language_subtitle"]
         }
 
     def __on_search_key_pressed(self, *args):
-        keywords = self.entry_search_language.get_text().lower()
-        keywords = re.sub(r"[^a-zA-Z0-9 ]", "", keywords)
+        keywords = re.sub(r"[^a-zA-Z0-9 ]", "", self.entry_search_language.get_text().lower())
 
-        if keywords == "" or len(keywords) < 3:
-            return
-
-        for locale, lang in all_languages.items():
-            lang = re.sub(r"[^a-zA-Z0-9 ]", "", lang)
-            if re.search(keywords, lang, re.IGNORECASE):
-                self.combo_languages.set_selected(
-                    list(all_languages.keys()).index(locale)
-                )
-                break
+        for row in self.all_languages_group:
+            row_title = re.sub(r'[^a-zA-Z0-9 ]', '', row.get_title().lower())
+            row_subtitle = re.sub(r'[^a-zA-Z0-9 ]', '', row.suffix_bin.get_label().lower())
+            search_text = row_title + ' ' + row_subtitle
+            row.set_visible(re.search(keywords, search_text, re.IGNORECASE) is not None)

--- a/vanilla_installer/gtk/default-language.ui
+++ b/vanilla_installer/gtk/default-language.ui
@@ -3,61 +3,60 @@
     <requires lib="gtk" version="4.0"/>
     <requires lib="libadwaita" version="1.0" />
     <template class="VanillaDefaultLanguage" parent="AdwBin">
-        <property name="halign">fill</property>
-        <property name="valign">fill</property>
         <property name="hexpand">true</property>
         <child>
-            <object class="GtkBox">
-                <property name="vexpand">true</property>
-                <property name="hexpand">true</property>
-                <child>
-                    <object class="GtkOverlay">
+            <object class="GtkOverlay">
+                <property name="valign">center</property>
+                <child type="overlay">
+                    <object class="GtkButton" id="btn_next">
+                        <property name="margin-end">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="icon-name">go-next-symbolic</property>
+                        <property name="halign">end</property>
                         <property name="valign">center</property>
-                        <child type="overlay">
-                            <object class="GtkButton" id="btn_next">
-                                <property name="margin-end">12</property>
-                                <property name="margin-start">12</property>
-                                <property name="icon-name">go-next-symbolic</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <property name="tooltip-text" translatable="yes">Next</property>
-                                <style>
-                                    <class name="circular" />
-                                    <class name="suggested-action" />
-                                </style>
+                        <property name="tooltip-text" translatable="yes">Next</property>
+                        <style>
+                            <class name="circular" />
+                            <class name="suggested-action" />
+                        </style>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwPreferencesPage">
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="margin-top">12</property>
+                                        <property name="margin-bottom">24</property>
+                                        <property name="wrap">True</property>
+                                        <property name="justify">center</property>
+                                        <property name="label" translatable="yes">Language</property>
+                                        <style>
+                                            <class name="title-1" />
+                                        </style>
+                                    </object>
+                                </child>
                             </object>
                         </child>
                         <child>
-                            <object class="AdwStatusPage" id="status_page">
-                                <property name="icon-name">preferences-desktop-locale-symbolic</property>
-                                <property name="title" translatable="yes">Language</property>
-                                <property name="description" translatable="yes">Select your language</property>
+                            <object class="AdwPreferencesGroup">
                                 <child>
-                                    <object class="AdwClamp">
-                                        <property name="maximum-size">570</property>
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="orientation">vertical</property>
-                                                <child>
-                                                    <object class="GtkSearchEntry" id="entry_search_language">
-                                                        <property name="hexpand">true</property>
-                                                        <property name="placeholder-text" translatable="yes">Search for a language</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="AdwPreferencesGroup">
-                                                        <child>
-                                                            <object class="AdwComboRow" id="combo_languages">
-                                                                <property name="title" translatable="yes">Language</property>
-                                                                <property name="model">
-                                                                    <object class="GtkStringList" id="str_list_languages"></object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
+                                    <object class="GtkSearchEntry" id="entry_search_language">
+                                        <property name="hexpand">true</property>
+                                        <property name="placeholder-text" translatable="yes">Search for language</property>
+                                        <property name="margin-bottom">12</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <child>
+                                    <object class="GtkListBox" id="all_languages_group">
+                                        <style>
+                                            <class name="boxed-list" />
+                                        </style>
                                     </object>
                                 </child>
                             </object>

--- a/vanilla_installer/gtk/widget-language.ui
+++ b/vanilla_installer/gtk/widget-language.ui
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="LanguageRow" parent="AdwActionRow">
+    <child type="prefix">
+      <object class="GtkCheckButton" id="select_button"></object>
+    </child>
+    <property name="activatable-widget">select_button</property>
+    <child type="suffix">
+      <object class="GtkLabel" id="suffix_bin">
+        <property name="justify">center</property>
+        <property name="label" translatable="yes">Language</property>
+        <style>
+          <class name="monospace" />
+          <class name="dim-label" />
+      </style>
+      </object>
+  </child>
+  </template>
+</interface>

--- a/vanilla_installer/vanilla-installer.gresource.xml
+++ b/vanilla_installer/vanilla-installer.gresource.xml
@@ -30,6 +30,7 @@
     <file>gtk/widget-disk.ui</file>
     <file>gtk/widget-partition-row.ui</file>
     <file>gtk/widget-partition.ui</file>
+    <file>gtk/widget-language.ui</file>
     <file>gtk/wireless-row.ui</file>
 
     <file>gtk/layout-preferences.ui</file>
@@ -48,4 +49,3 @@
     <file preprocess="xml-stripblanks">../data/icons/hicolor/symbolic/actions/vanilla-logo-text-symbolic.svg</file>
   </gresource>
 </gresources>
-


### PR DESCRIPTION
- changed the layout of welcome screen to better align with [vanilla installer mockup](https://github.com/Vanilla-OS/mockups/issues/2)
- screen shots:

| default state | search state | 
| ------------------- |---------------------- |
| ![Screenshot from 2023-08-28 10-48-00](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/4ad8330b-8b27-4de7-b3b7-381b0f096240) | ![Screenshot from 2023-08-28 10-48-08](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/2c7bd5da-fec6-4349-99d2-588ddf28096c)

_Note: Please dont merge this yet, would be better to merge once keyboard and Timezone page are also adapted_