### PR TITLE
update the look of timezone screen

### DIFF
--- a/vanilla_installer/gtk/default-timezone.ui
+++ b/vanilla_installer/gtk/default-timezone.ui
@@ -3,75 +3,60 @@
     <requires lib="gtk" version="4.0"/>
     <requires lib="libadwaita" version="1.0" />
     <template class="VanillaDefaultTimezone" parent="AdwBin">
-        <property name="halign">fill</property>
-        <property name="valign">fill</property>
         <property name="hexpand">true</property>
         <child>
-            <object class="GtkBox">
-                <property name="vexpand">true</property>
-                <property name="hexpand">true</property>
-                <child>
-                    <object class="GtkOverlay">
+            <object class="GtkOverlay">
+                <property name="valign">center</property>
+                <child type="overlay">
+                    <object class="GtkButton" id="btn_next">
+                        <property name="margin-end">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="icon-name">go-next-symbolic</property>
+                        <property name="halign">end</property>
                         <property name="valign">center</property>
-                        <child type="overlay">
-                            <object class="GtkButton" id="btn_next">
-                                <property name="margin-end">12</property>
-                                <property name="margin-start">12</property>
-                                <property name="icon-name">go-next-symbolic</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <property name="tooltip-text" translatable="yes">Next</property>
-                                <style>
-                                    <class name="circular" />
-                                    <class name="suggested-action" />
-                                </style>
+                        <property name="tooltip-text" translatable="yes">Next</property>
+                        <style>
+                            <class name="circular" />
+                            <class name="suggested-action" />
+                        </style>
+                    </object>
+                </child>
+                <child>
+                    <object class="AdwPreferencesPage">
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <child>
+                                    <object class="GtkLabel">
+                                        <property name="margin-top">12</property>
+                                        <property name="margin-bottom">24</property>
+                                        <property name="wrap">True</property>
+                                        <property name="justify">center</property>
+                                        <property name="label" translatable="yes">Timezone</property>
+                                        <style>
+                                            <class name="title-1" />
+                                        </style>
+                                    </object>
+                                </child>
                             </object>
                         </child>
                         <child>
-                            <object class="AdwStatusPage" id="status_page">
-                                <property name="icon-name">preferences-system-time-symbolic</property>
-                                <property name="title" translatable="yes">Date &amp; Time</property>
-                                <property name="description" translatable="yes">Select your preferred timezone</property>
+                            <object class="AdwPreferencesGroup">
                                 <child>
-                                    <object class="AdwClamp">
-                                        <property name="maximum-size">570</property>
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="orientation">vertical</property>
-                                                <child>
-                                                    <object class="GtkSearchEntry" id="entry_search_timezone">
-                                                        <property name="hexpand">true</property>
-                                                        <property name="placeholder-text" translatable="yes">Search for a Timezone</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="AdwPreferencesGroup">
-                                                        <child>
-                                                            <object class="AdwComboRow" id="combo_region">
-                                                                <property name="title" translatable="yes">Region</property>
-                                                                <property name="model">
-                                                                    <object class="GtkStringList" id="str_list_region"></object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                        <child>
-                                                            <object class="AdwComboRow" id="combo_zone">
-                                                                <property name="title" translatable="yes">Zone</property>
-                                                                <property name="model">
-                                                                    <object class="GtkStringList" id="str_list_zone"></object>
-                                                                </property>
-                                                            </object>
-                                                        </child>
-                                                        <child>
-                                                            <object class="AdwActionRow" id="row_preview">
-                                                                <property name="title">19:07:00</property>
-                                                                <property name="subtitle">Saturday, 29 Oct 2022</property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
+                                    <object class="GtkSearchEntry" id="entry_search_timezone">
+                                        <property name="hexpand">true</property>
+                                        <property name="placeholder-text" translatable="yes">Search your preferred timezone</property>
+                                        <property name="margin-bottom">12</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="AdwPreferencesGroup">
+                                <child>
+                                    <object class="GtkListBox" id="all_timezones_group">
+                                        <style>
+                                            <class name="boxed-list" />
+                                        </style>
                                     </object>
                                 </child>
                             </object>

--- a/vanilla_installer/gtk/widget-timezone.ui
+++ b/vanilla_installer/gtk/widget-timezone.ui
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="TimezoneRow" parent="AdwActionRow">
+    <child type="prefix">
+      <object class="GtkCheckButton" id="select_button"></object>
+    </child>
+    <property name="activatable-widget">select_button</property>
+    <child type="suffix">
+      <object class="GtkLabel" id="country_label">
+        <style>
+          <class name="dim-label" />
+        </style>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/vanilla_installer/vanilla-installer.gresource.xml
+++ b/vanilla_installer/vanilla-installer.gresource.xml
@@ -32,6 +32,7 @@
     <file>gtk/widget-partition-row.ui</file>
     <file>gtk/widget-partition.ui</file>
     <file>gtk/widget-language.ui</file>
+    <file>gtk/widget-timezone.ui</file>
     <file>gtk/wireless-row.ui</file>
 
     <file>gtk/layout-preferences.ui</file>


### PR DESCRIPTION
- changed the layout of welcome screen to better align with [vanilla installer mockup](https://github.com/Vanilla-OS/mockups/issues/2)
- screenshots:

| default state | search state | 
| ------------------- |---------------------- |
| ![image](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/3514e118-197e-4947-8ce4-902e22ff57d2) | ![image](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/d4a78dc0-4f19-4070-afb0-69114a7d20fb) |

closes #255 