### PR TITLE
Fix: Network page crash

### DIFF
--- a/vanilla_installer/defaults/network.py
+++ b/vanilla_installer/defaults/network.py
@@ -354,6 +354,7 @@ class VanillaDefaultNetwork(Adw.Bin):
                 self.__scan_wifi(device)
 
         self.set_btn_next(self.has_eth_connection or self.has_wifi_connection)
+        return GLib.SOURCE_REMOVE
 
     def __start_auto_refresh(self):
         def run_async():


### PR DESCRIPTION
According to PyGObject's [documentation](https://lazka.github.io/pgi-docs/#GLib-2.0/functions.html#GLib.idle_add):

> If the function returns [GLib.SOURCE_REMOVE](https://lazka.github.io/pgi-docs/GLib-2.0/constants.html#GLib.SOURCE_REMOVE) or [False](https://docs.python.org/3/library/constants.html#False) it is automatically removed from the list of event sources and will not be called again.

What I think was happening is that, by not providing a return value, GLib tried to invoke the function again, even after it had been disposed by Python's garbage collector, causing a crash. I left the installer open for quite some time and couldn't reproduce the crash anymore.