### PR TITLE
Fix: Broken locales after installation

### DIFF
--- a/vanilla_installer/utils/processor.py
+++ b/vanilla_installer/utils/processor.py
@@ -154,6 +154,7 @@ mount -t overlay overlay -o lowerdir=/.system/etc,upperdir=/var/lib/abroot/etc/v
 mount -o bind /var/home /home
 mount -o bind /var/opt /opt
 mount -o bind,ro /.system/usr /usr
+mount -o bind /var/lib/abroot/etc/vos-a/locales /usr/lib/locale
 """
 
 _SYSTEMD_MOUNT_UNIT = """[Unit]
@@ -636,6 +637,8 @@ class Processor:
                     "mount -o bind /var/home /home",
                     "mount -o bind /var/opt /opt",
                     "mount -o bind,ro /.system/usr /usr",
+                    "mkdir -p /var/lib/abroot/etc/vos-a/locales",
+                    "mount -o bind /var/lib/abroot/etc/vos-a/locales /usr/lib/locale",
                 ],
                 chroot=True,
             )


### PR DESCRIPTION
This PR solves the issue where locales would be generated but not properly recognized by the system after installation. We solve this by bind mounting a new locales directory, stored in the mutable part of the system (/var/lib/abroot/etc/vos-a/locales), into the original locales directory in /usr/lib. This mount is done in the same way as /home and /opt, which are mounted via Systemd unit.