### PR TITLE
fix: set the sensitive state for `btn_next`

### DIFF
--- a/vanilla_installer/defaults/keyboard.py
+++ b/vanilla_installer/defaults/keyboard.py
@@ -93,6 +93,7 @@ class VanillaDefaultKeyboard(Adw.Bin):
         )
         self.all_keyboards_group.connect("row-selected", self.__keyboard_verify)
         self.all_keyboards_group.connect("row-activated", self.__keyboard_verify)
+        self.__window.carousel.connect("page-changed", self.__keyboard_verify)
 
         self.search_controller.connect("key-released", self.__on_search_key_pressed)
         if "VANILLA_NO_APPLY_XKB" not in os.environ:
@@ -171,6 +172,8 @@ class VanillaDefaultKeyboard(Adw.Bin):
                 and current_variant == keyboard_variant
             ):
                 keyboard_row.select_button.set_active(True)
+                self.selected_keyboard["layout"] = current_layout
+                self.selected_keyboard["variant"] = current_variant
 
         return keyboard_widgets
 

--- a/vanilla_installer/defaults/language.py
+++ b/vanilla_installer/defaults/language.py
@@ -67,8 +67,21 @@ class VanillaDefaultLanguage(Adw.Bin):
 
         # signals
         self.btn_next.connect("clicked", self.__window.next)
+        self.all_languages_group.connect(
+            "selected-rows-changed", self.__language_verify
+        )
+        self.all_languages_group.connect("row-selected", self.__language_verify)
+        self.all_languages_group.connect("row-activated", self.__language_verify)
+        self.__window.carousel.connect("page-changed", self.__language_verify)
+        
         self.search_controller.connect("key-released", self.__on_search_key_pressed)
         self.entry_search_language.add_controller(self.search_controller)
+
+    def __language_verify(self, *args):
+        if self.selected_language["language_subtitle"] is not None:
+            self.btn_next.set_sensitive(True)
+        else:
+            self.btn_next.set_sensitive(False)
 
     def __generate_language_list_widgets(self):
         for language_code, language_title in all_languages.items():
@@ -83,6 +96,8 @@ class VanillaDefaultLanguage(Adw.Bin):
 
             if current_language == language_code:
                 language_row.select_button.set_active(True)
+                self.selected_language["language_title"] = language_title
+                self.selected_language["language_subtitle"] = language_code
 
     def get_finals(self):
         return {"language": self.selected_language["language_subtitle"]}

--- a/vanilla_installer/defaults/timezone.py
+++ b/vanilla_installer/defaults/timezone.py
@@ -88,8 +88,21 @@ class VanillaDefaultTimezone(Adw.Bin):
 
         # signals
         self.btn_next.connect("clicked", self.__window.next)
+        self.all_timezones_group.connect(
+            "selected-rows-changed", self.__timezone_verify
+        )
+        self.all_timezones_group.connect("row-selected", self.__timezone_verify)
+        self.all_timezones_group.connect("row-activated", self.__timezone_verify)
+        self.__window.carousel.connect("page-changed", self.__timezone_verify)
+
         self.search_controller.connect("key-released", self.__on_search_key_pressed)
         self.entry_search_timezone.add_controller(self.search_controller)
+
+    def __timezone_verify(self, *args):
+        if self.selected_timezone["region"] and self.selected_timezone["zone"] is not None:
+            self.btn_next.set_sensitive(True)
+        else:
+            self.btn_next.set_sensitive(False)
 
     def get_finals(self):
         try:
@@ -131,3 +144,5 @@ class VanillaDefaultTimezone(Adw.Bin):
         for row in self.__timezone_rows:
             if current_city == row.title and current_country == row.subtitle:
                 row.select_button.set_active(True)
+                self.selected_timezone["zone"] = current_city
+                self.selected_timezone["region"] = current_country

--- a/vanilla_installer/gtk/default-keyboard.ui
+++ b/vanilla_installer/gtk/default-keyboard.ui
@@ -86,6 +86,7 @@
                                         </child>
                                         <child>
                                             <object class="AdwClamp">
+                                                <property name="maximum-size">615</property>
                                                 <child>
                                                     <object class="AdwPreferencesGroup">
                                                         <property name="margin-top">6</property>

--- a/vanilla_installer/gtk/default-language.ui
+++ b/vanilla_installer/gtk/default-language.ui
@@ -9,6 +9,7 @@
                 <property name="valign">center</property>
                 <child type="overlay">
                     <object class="GtkButton" id="btn_next">
+                        <property name="sensitive">False</property>
                         <property name="margin-end">12</property>
                         <property name="margin-start">12</property>
                         <property name="icon-name">go-next-symbolic</property>

--- a/vanilla_installer/gtk/default-timezone.ui
+++ b/vanilla_installer/gtk/default-timezone.ui
@@ -9,6 +9,7 @@
                 <property name="valign">center</property>
                 <child type="overlay">
                     <object class="GtkButton" id="btn_next">
+                        <property name="sensitive">False</property>
                         <property name="margin-end">12</property>
                         <property name="margin-start">12</property>
                         <property name="icon-name">go-next-symbolic</property>


### PR DESCRIPTION
 #### changes:
 - set the `btn_next` sensitive state when carousel page-changed.
 - set the values in selected_group if current_values are present
 - added verify_check to `language`, `timezone` similar to the one already present in `keyboard` 
 
 #### other/misc:
- matched the `test_entry` clamp max-size to `all_keyboard_group` width