### PR TITLE
update to `AdwToolbarView`

### DIFF
--- a/vanilla_installer/gtk/window.ui
+++ b/vanilla_installer/gtk/window.ui
@@ -6,64 +6,65 @@
     <property name="default-width">900</property>
     <property name="default-height">680</property>
     <property name="title" translatable="yes">Vanilla OS Installer</property>
+    <property name="deletable">False</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="AdwHeaderBar">
-            <property name="show-end-title-buttons">False</property>
-            <style>
-              <class name="flat"/>
-            </style>
-            <property name="title_widget">
-              <object class="AdwCarouselIndicatorDots" id="carousel_indicator_dots">
-                <property name="carousel">carousel</property>
-                <property name="orientation">horizontal</property>
-                <property name="visible">False</property>
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkOverlay">
-            <property name="valign">center</property>
-            <child type="overlay">
-              <object class="GtkButton" id="btn_back">
-                <property name="visible">False</property>
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <property name="icon-name">go-previous-symbolic</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="tooltip-text" translatable="yes">Back</property>
-                <style>
-                  <class name="circular"/>
-                </style>
+      <object class="AdwBin">
+        <property name="child">
+          <object class="AdwToolbarView">
+            <child type="top">
+              <object class="AdwHeaderBar">
+                <property name="show-end-title-buttons">False</property>
+                <property name="title_widget">
+                  <object class="AdwCarouselIndicatorDots" id="carousel_indicator_dots">
+                    <property name="carousel">carousel</property>
+                    <property name="orientation">horizontal</property>
+                    <property name="visible">False</property>
+                  </object>
+                </property>
               </object>
             </child>
-            <child>
-              <object class="GtkBox">
-                <property name="orientation">horizontal</property>
-                <property name="vexpand">true</property>
-                <property name="hexpand">true</property>
+            <property name="content">
+              <object class="GtkOverlay">
+                <property name="valign">center</property>
+                <child type="overlay">
+                  <object class="GtkButton" id="btn_back">
+                    <property name="visible">False</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="icon-name">go-previous-symbolic</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="tooltip-text" translatable="yes">Back</property>
+                    <style>
+                      <class name="circular"/>
+                    </style>
+                  </object>
+                </child>
                 <child>
-                  <object class="AdwToastOverlay" id="toasts">
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="vexpand">true</property>
+                    <property name="hexpand">true</property>
                     <child>
-                      <object class="AdwCarousel" id="carousel">
-                        <property name="vexpand">True</property>
-                        <property name="hexpand">True</property>
-                        <property name="allow_scroll_wheel">False</property>
-                        <property name="allow_mouse_drag">False</property>
-                        <property name="allow_long_swipes">False</property>
-                        <property name="interactive">False</property>
+                      <object class="AdwToastOverlay" id="toasts">
+                        <child>
+                          <object class="AdwCarousel" id="carousel">
+                            <property name="vexpand">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="allow_scroll_wheel">False</property>
+                            <property name="allow_mouse_drag">False</property>
+                            <property name="allow_long_swipes">False</property>
+                            <property name="interactive">False</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-            </child>
+            </property>
           </object>
-        </child>
+        </property>
       </object>
     </child>
   </template>


### PR DESCRIPTION
- drop `flat` style in `AdwApplicationWindow` and use `AdwToolbarView`

#### screenshots:
| default state | scrolled-up state | 
| ------------------ | ------------------------- |
|![image](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/cb35bca2-a29e-4209-9f12-5e386a3f8db4) |![image](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/9ba43e77-029f-402b-9c9f-135b63134e43) |

_changes: in default state it uses `flat` and when scrolled up for content it shows separator after `AdwHeaderBar`_