### PR TITLE
fix #315 and #317

### DIFF
--- a/recipe.json
+++ b/recipe.json
@@ -34,17 +34,17 @@
         "welcome": {
             "template": "welcome"
         },
-        "network": {
-            "template": "network"
-        },
-        "conn-check": {
-            "template": "conn-check"
-        },
         "language": {
             "template": "language"
         },
         "keyboard": {
             "template": "keyboard"
+        },
+        "network": {
+            "template": "network"
+        },
+        "conn-check": {
+            "template": "conn-check"
         },
         "timezone": {
             "template": "timezone"

--- a/vanilla_installer/defaults/conn_check.py
+++ b/vanilla_installer/defaults/conn_check.py
@@ -100,7 +100,7 @@ class VanillaDefaultConnCheck(Adw.Bin):
             self.status_page.set_icon_name("network-wired-disconnected-symbolic")
             self.status_page.set_title(_("No Internet Connection!"))
             self.status_page.set_description(
-                _("First Setup requires an active internet connection")
+                _("Installer requires an active internet connection")
             )
             self.btn_recheck.set_visible(True)
 

--- a/vanilla_installer/gtk/default-keyboard.ui
+++ b/vanilla_installer/gtk/default-keyboard.ui
@@ -36,6 +36,8 @@
                         </child>
                         <child>
                             <object class="AdwStatusPage" id="status_page">
+                                <property name="hexpand">true</property>
+                                <property name="vexpand">true</property>
                                 <property name="icon-name">input-keyboard-symbolic</property>
                                 <property name="title" translatable="yes">Keyboard Layout</property>
                                 <property name="description" translatable="yes">Select your preferred keyboard layout</property>


### PR DESCRIPTION
- fix: #315 
   - added `hexpand` and `vexpand` properties

| before | after |
| -----------|------- |
| ![image](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/c0920b9d-4c1e-4c32-9dbd-a87779eabd97)  |![image](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/976881a6-6c88-4da2-88b3-32a41c65a539) |

- fix: #317
   - moved _Language_, _Keyboard_ pages before network related pages.
 