### PR TITLE
update tour+dialog-output

### DIFF
--- a/vanilla_installer/gtk/dialog-output.ui
+++ b/vanilla_installer/gtk/dialog-output.ui
@@ -1,19 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <requires lib="gtk" version="4.0"/>
-    <requires lib="libadwaita" version="1.0" />
-    <template class="VanillaDialogOutput" parent="AdwWindow">
-        <property name="title" translatable="yes">Log</property>
-        <property name="modal">true</property>
-        <property name="default-width">500</property>
-        <property name="default-height">450</property>
-        <child>
-            <object class="GtkBox" id="main_box">
-                <property name="orientation">vertical</property>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0" />
+  <template class="VanillaDialogOutput" parent="AdwWindow">
+    <property name="title" translatable="yes">Log</property>
+    <property name="modal">true</property>
+    <property name="default-width">500</property>
+    <property name="default-height">500</property>
+    <child>
+      <object class="AdwBin">
+        <property name="child">
+          <object class="AdwToolbarView">
+            <child type="top">
+              <object class="AdwHeaderBar" />
+            </child>
+            <property name="content">
+              <object class="AdwBin">
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <style>
+                  <class name="card"/>
+                </style>
                 <child>
-                    <object class="AdwHeaderBar"></object>
+                  <object class="GtkBox" id="main_box">
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
+                  </object>
                 </child>
-            </object>
-        </child>
-    </template>
+              </object>
+            </property>
+          </object>
+        </property> 
+      </object>
+    </child>
+  </template>
 </interface>

--- a/vanilla_installer/gtk/progress.ui
+++ b/vanilla_installer/gtk/progress.ui
@@ -14,21 +14,61 @@
                 <property name="height-request">550</property>
                 <property name="orientation">vertical</property>
                 <child>
-                    <object class="AdwCarousel" id="carousel_tour">
-                        <property name="halign">fill</property>
-                        <property name="valign">fill</property>
-                        <property name="hexpand">true</property>
-                        <property name="vexpand">true</property>
-                        <property name="allow_scroll_wheel">False</property>
-                        <property name="allow_mouse_drag">False</property>
-                        <property name="allow_long_swipes">False</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="AdwCarouselIndicatorDots">
-                        <property name="carousel">carousel_tour</property>
-                        <property name="orientation">horizontal</property>
-                        <property name="margin-bottom">18</property>
+                    <object class="GtkOverlay">
+                        <property name="valign">center</property>
+                        <child type="overlay">
+                            <object class="GtkButton" id="tour_btn_back">
+                                <property name="visible">False</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="icon-name">go-previous-symbolic</property>
+                                <property name="halign">start</property>
+                                <property name="valign">center</property>
+                                <property name="tooltip-text" translatable="yes">Previous</property>
+                                <style>
+                                <class name="circular" />
+                                </style>
+                            </object>
+                        </child>
+                        <child type="overlay">
+                            <object class="GtkButton" id="tour_btn_next">
+                                <property name="visible">False</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="icon-name">go-next-symbolic</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <property name="tooltip-text" translatable="yes">Next</property>
+                                <style>
+                                <class name="circular" />
+                                </style>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="vexpand">true</property>
+                                <property name="hexpand">true</property>
+                                <child>
+                                    <object class="AdwCarousel" id="carousel_tour">
+                                        <property name="halign">fill</property>
+                                        <property name="valign">fill</property>
+                                        <property name="hexpand">true</property>
+                                        <property name="vexpand">true</property>
+                                        <property name="allow_scroll_wheel">False</property>
+                                        <property name="allow_mouse_drag">False</property>
+                                        <property name="allow_long_swipes">False</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="AdwCarouselIndicatorDots">
+                                        <property name="carousel">carousel_tour</property>
+                                        <property name="orientation">horizontal</property>
+                                        <property name="margin-bottom">18</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
                     </object>
                 </child>
             </object>

--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -30,6 +30,8 @@ class VanillaProgress(Gtk.Box):
     carousel_tour = Gtk.Template.Child()
     tour_button = Gtk.Template.Child()
     tour_box = Gtk.Template.Child()
+    tour_btn_back = Gtk.Template.Child()
+    tour_btn_next = Gtk.Template.Child()
     progressbar = Gtk.Template.Child()
     console_button = Gtk.Template.Child()
     console_box = Gtk.Template.Child()
@@ -52,6 +54,9 @@ class VanillaProgress(Gtk.Box):
 
         self.style_manager.connect("notify::dark", self.__on_setup_terminal_colors)
         self.tour_button.connect("clicked", self.__on_tour_button)
+        self.tour_btn_back.connect("clicked", self.__on_tour_back)
+        self.tour_btn_next.connect("clicked", self.__on_tour_next)
+        self.carousel_tour.connect("page-changed", self.__on_page_changed)
         self.console_button.connect("clicked", self.__on_console_button)
 
 
@@ -60,7 +65,7 @@ class VanillaProgress(Gtk.Box):
         is_dark: bool = self.style_manager.get_dark()
 
         palette = [
-            "#3d3d3d",
+            "#363636",
             "#c01c28",
             "#26a269",
             "#a2734c",
@@ -103,6 +108,23 @@ class VanillaProgress(Gtk.Box):
         self.console_box.set_visible(False)
         self.tour_button.set_visible(False)
         self.console_button.set_visible(True)
+
+    def __on_tour_back(self, *args):
+        cur_index = self.carousel_tour.get_position()
+        page = self.carousel_tour.get_nth_page(cur_index - 1)
+        self.carousel_tour.scroll_to(page, True)
+
+    def __on_tour_next(self, *args):
+        cur_index = self.carousel_tour.get_position()
+        page = self.carousel_tour.get_nth_page(cur_index + 1)
+        self.carousel_tour.scroll_to(page, True)
+
+    def __on_page_changed(self, *args):
+        position = self.carousel_tour.get_position()
+        pages = self.carousel_tour.get_n_pages()
+
+        self.tour_btn_back.set_visible(position < pages and position > 0)
+        self.tour_btn_next.set_visible(position < pages - 1)
 
     def __on_console_button(self, *args):
         self.tour_box.set_visible(False)


### PR DESCRIPTION
- added previous and forward buttons in tour for navigation.
- updated `dialog-output.ui` to look pretty.

#### screenshots:
| before | after |
| ---------- | ------- |
| ![Screenshot from 2023-12-24 23-36-56](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/5d73c39c-fda1-4336-b509-cd2595321cb2) | ![Screenshot from 2023-12-24 23-35-04](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/726fa857-6454-4ff7-bd7c-3dca70853e6a) |
| ![Screenshot from 2023-12-24 23-37-40](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/190447e2-4cdf-442b-ab6a-287443d85488) | ![Screenshot from 2023-12-24 23-36-13](https://github.com/Vanilla-OS/vanilla-installer/assets/54065734/eae85711-07ce-4e31-9459-88088155b789) |
