### PR TITLE
feat:[#306] Have option to not format EFI partition

### DIFF
--- a/vanilla_installer/defaults/disk.py
+++ b/vanilla_installer/defaults/disk.py
@@ -571,12 +571,19 @@ class VanillaDefaultDiskConfirmModal(Adw.Window):
                 if partition == "disk":
                     continue
                 entry.set_title(partition)
-                entry.set_subtitle(
-                    _("Will be formatted in {} and mounted in {}").format(
-                        partition_recipe[partition]["fs"],
-                        partition_recipe[partition]["mp"],
+                if partition_recipe[partition]["fs"] == "unformatted":
+                    entry.set_subtitle(
+                        _("Will be mounted in {}").format(
+                            partition_recipe[partition]["mp"],
+                        )
                     )
-                )
+                else:
+                    entry.set_subtitle(
+                        _("Will be formatted in {} and mounted in {}").format(
+                            partition_recipe[partition]["fs"],
+                            partition_recipe[partition]["mp"],
+                        )
+                    )
             self.group_partitions.add(entry)
 
     def __on_btn_cancel_clicked(self, widget):

--- a/vanilla_installer/defaults/disk.py
+++ b/vanilla_installer/defaults/disk.py
@@ -410,12 +410,10 @@ class PartitionSelector(Adw.PreferencesPage):
         self.update_apply_button_status()
 
     def __on_keep_efi_toggled(self, widget, state):
-        print(state)
         if state:
             self.__selected_partitions["efi_part_expand"]["fstype"] = "unformatted"
         else:
             self.__selected_partitions["efi_part_expand"]["fstype"] = "fat32"
-        print(self.__selected_partitions["efi_part_expand"]["fstype"])
 
     def update_partition_rows(self):
         rows = [

--- a/vanilla_installer/defaults/disk.py
+++ b/vanilla_installer/defaults/disk.py
@@ -159,6 +159,7 @@ class PartitionSelector(Adw.PreferencesPage):
     swap_part_expand = Gtk.Template.Child()
 
     use_swap_part = Gtk.Template.Child()
+    keep_efi_part = Gtk.Template.Child()
 
     boot_small_error = Gtk.Template.Child()
     efi_small_error = Gtk.Template.Child()
@@ -213,6 +214,7 @@ class PartitionSelector(Adw.PreferencesPage):
 
         self.launch_gparted.connect("clicked", self.__on_launch_gparted)
         self.use_swap_part.connect("state-set", self.__on_use_swap_toggled)
+        self.keep_efi_part.connect("state-set", self.__on_keep_efi_toggled)
 
         self.__boot_part_rows = self.__generate_partition_list_widgets(
             self.boot_part_expand, "ext4", False
@@ -406,6 +408,14 @@ class PartitionSelector(Adw.PreferencesPage):
             self.update_partition_rows()
 
         self.update_apply_button_status()
+
+    def __on_keep_efi_toggled(self, widget, state):
+        print(state)
+        if state:
+            self.__selected_partitions["efi_part_expand"]["fstype"] = "unformatted"
+        else:
+            self.__selected_partitions["efi_part_expand"]["fstype"] = "fat32"
+        print(self.__selected_partitions["efi_part_expand"]["fstype"])
 
     def update_partition_rows(self):
         rows = [

--- a/vanilla_installer/gtk/widget-partition.ui
+++ b/vanilla_installer/gtk/widget-partition.ui
@@ -54,6 +54,18 @@
             <property name="subtitle" translatable="yes">Please select a partition from the options below</property>
           </object>
         </child>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Keep EFI</property>
+            <property name="subtitle" translatable="yes">Choose to not format your EFI partition. Make sure this is turned on if you are dual-booting</property>
+            <child type="suffix">
+              <object class="GtkSwitch" id="keep_efi_part">
+                <property name="valign">3</property>
+              </object>
+            </child>
+            <property name="activatable-widget">keep_efi_part</property>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/vanilla_installer/utils/processor.py
+++ b/vanilla_installer/utils/processor.py
@@ -334,6 +334,9 @@ class Processor:
             def setup_partition(
                 part_name: str, encrypt: bool = False, password: str = None
             ):
+                mountpoints.append([part, values["mp"]])
+                if values["fs"] == "unformatted":
+                    return
                 format_args = [part_number, values["fs"]]
                 if encrypt:
                     operation = "luks-format"
@@ -343,7 +346,6 @@ class Processor:
                     operation = "format"
                 format_args.append(part_name)
                 setup_steps.append([part_disk, operation, format_args])
-                mountpoints.append([part, values["mp"]])
 
             if values["mp"] == "/":
                 part_prefix = (


### PR DESCRIPTION
This PR adds an option to keep the EFI partition during install. As of now, the only indication that it works is through VANILLA_FAKE's JSON dump. This has not yet been tested on a Vanilla OS system without VANILLA_FAKE.

This PR works like this:
- The manual partitioning page has a toggle to keep the EFI partition. This toggle sets the fstype of the EFI partition to 'unformatted'.
- The processor skips adding the format option of any partition that has the 'unformatted' fstype. Note that the mountpoint is added before the return statement so that the EFI file can still be added.

I would like to stress again that this has not yet been tested on a live system. If I get the time, I will do it later. Any independant tests would be appreciated to make sure that there are no unexpected surprises.

Closes #306 