### PR TITLE
fix[#301]: Generate UUID with NM

### DIFF
--- a/vanilla_installer/defaults/network.py
+++ b/vanilla_installer/defaults/network.py
@@ -216,6 +216,7 @@ class WirelessRow(Adw.ActionRow):
         connection = NM.SimpleConnection.new()
         s_con = NM.SettingConnection.new()
         s_con.set_property(NM.SETTING_CONNECTION_ID, self.ssid)
+        s_con.set_property(NM.SETTING_CONNECTION_UUID, NM.utils_uuid_generate())
         s_con.set_property(NM.SETTING_CONNECTION_TYPE, "802-11-wireless")
         s_wifi = NM.SettingWireless.new()
         s_wifi.set_property(NM.SETTING_WIRELESS_SSID, self.ap.get_ssid())


### PR DESCRIPTION
Use the NM UUID generate function to avoid UUID pointer assertion error

The function is documented [here](https://lazka.github.io/pgi-docs/#NM-1.0/functions.html#NM.utils_uuid_generate).  Tested this locally and it seems to work without issue.

Can I get someone else to test and confirm?