### PR TITLE
saves configuration in usr

### DIFF
--- a/vanilla_installer/utils/processor.py
+++ b/vanilla_installer/utils/processor.py
@@ -720,6 +720,7 @@ class Processor:
             [
                 "mkdir -p /etc/abroot",
                 'echo "$(head -n-1 /usr/share/abroot/abroot.json),\n    \\"thinProvisioning\\": true,\n    \\"thinInitVolume\\": \\"vos-init\\"\n}" > /etc/abroot/abroot.json',
+                'cp /etc/abroot/abroot.json /usr/share/abroot/abroot.json',
             ],
             chroot=True,
         )


### PR DESCRIPTION
This ensures that there is a valid configuration in /usr

For details, see https://github.com/Vanilla-OS/ABRoot/pull/319 