### PR TITLE
adapts config to new abroot version

### DIFF
--- a/vanilla_installer/utils/processor.py
+++ b/vanilla_installer/utils/processor.py
@@ -719,7 +719,7 @@ class Processor:
             "shell",
             [
                 "mkdir -p /etc/abroot",
-                'echo "$(head -n-1 /usr/share/abroot/abroot.json),\n    \\"thinProvisioning\\": true,\n    \\"thinInitVolume\\": \\"vos-init\\"\n}" > /etc/abroot/abroot.json',
+                'echo "$(head -n-1 /usr/share/abroot/abroot.json),\n  \\"PartCryptVar\\": \\"/dev/mapper/vos--var-var\\",\n  \\"thinProvisioning\\": true,\n    \\"thinInitVolume\\": \\"vos-init\\"\n}" > /etc/abroot/abroot.json',
                 'cp /etc/abroot/abroot.json /usr/share/abroot/abroot.json',
             ],
             chroot=True,


### PR DESCRIPTION
This writes the correct config for abroot after this change:
https://github.com/Vanilla-OS/ABRoot/pull/324

It's not strictly necessary yet but I think it should be added for consistency.