### PR TITLE
Improve the performance by implementing Deltas

### DIFF
--- a/vanilla_installer/defaults/conn_check.py
+++ b/vanilla_installer/defaults/conn_check.py
@@ -42,6 +42,7 @@ class VanillaDefaultConnCheck(Adw.Bin):
         self.__key = key
         self.__step = step
         self.__step_num = step["num"]
+        self.delta = False
 
         self.__ignore_callback = False
 

--- a/vanilla_installer/defaults/disk.py
+++ b/vanilla_installer/defaults/disk.py
@@ -651,6 +651,7 @@ class VanillaDefaultDisk(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
         self.__registry_disks = []
         self.__selected_disks = []
         self.__disks = DisksManager()

--- a/vanilla_installer/defaults/encryption.py
+++ b/vanilla_installer/defaults/encryption.py
@@ -37,6 +37,7 @@ class VanillaDefaultEncryption(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
 
         self.btn_next.connect("clicked", self.__window.next)
         self.use_encryption_switch.connect(

--- a/vanilla_installer/defaults/image.py
+++ b/vanilla_installer/defaults/image.py
@@ -31,6 +31,7 @@ class VanillaDefaultImage(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
 
         self.btn_next.connect("clicked", self.__window.next)
         self.image_url_entry.connect(

--- a/vanilla_installer/defaults/keyboard.py
+++ b/vanilla_installer/defaults/keyboard.py
@@ -78,11 +78,14 @@ class VanillaDefaultKeyboard(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = True
         self.__keymaps = KeyMaps()
-
         self.__keyboard_rows = self.__generate_keyboard_list_widgets(
             self.selected_keyboard
         )
+
+
+    def gen_deltas(self):
         for i, widget in enumerate(self.__keyboard_rows):
             self.all_keyboards_group.append(widget)
 
@@ -102,6 +105,11 @@ class VanillaDefaultKeyboard(Adw.Bin):
         self.search_controller.connect("key-released", self.__on_search_key_pressed)
         if "VANILLA_NO_APPLY_XKB" not in os.environ:
             self.test_focus_controller.connect("enter", self.__apply_layout)
+
+
+    def del_deltas(self):
+        self.all_keyboards_group.remove_all()
+
 
     def __keyboard_verify(self, *args):
         if self.selected_keyboard != []:
@@ -192,7 +200,7 @@ class VanillaDefaultKeyboard(Adw.Bin):
                 self.__create_keyboard_layout_array(selected_keyboard) 
             ),
         )
-    
+
     def __create_keyboard_layout_array(self, selected_keyboard):
         keyboard_layout_array = []
         for i in selected_keyboard:

--- a/vanilla_installer/defaults/language.py
+++ b/vanilla_installer/defaults/language.py
@@ -60,10 +60,8 @@ class VanillaDefaultLanguage(Adw.Bin):
         self.__key = key
         self.__step = step
         self.__language_rows = []
-
+        self.delta = True
         self.__generate_language_list_widgets()
-        for widget in self.__language_rows:
-            self.all_languages_group.append(widget)
 
         # signals
         self.btn_next.connect("clicked", self.__window.next)
@@ -76,6 +74,15 @@ class VanillaDefaultLanguage(Adw.Bin):
 
         self.search_controller.connect("key-released", self.__on_search_key_pressed)
         self.entry_search_language.add_controller(self.search_controller)
+
+
+    def gen_deltas(self):
+        for widget in self.__language_rows:
+            self.all_languages_group.append(widget)
+
+
+    def del_deltas(self):
+        self.all_languages_group.remove_all()
 
     def __language_verify(self, *args):
         if self.selected_language["language_subtitle"] is not None:

--- a/vanilla_installer/defaults/network.py
+++ b/vanilla_installer/defaults/network.py
@@ -256,6 +256,7 @@ class VanillaDefaultNetwork(Adw.Bin):
         self.__step = step
         self.__nm_client = NM.Client.new()
         self.__step_num = step["num"]
+        self.delta = False
 
         self.__devices = []
         self.__wired_children = []

--- a/vanilla_installer/defaults/nvidia.py
+++ b/vanilla_installer/defaults/nvidia.py
@@ -34,6 +34,7 @@ class VanillaDefaultNvidia(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
 
         self.btn_yes.connect("clicked", self.use_proprietary_drivers)
         self.btn_no.connect("clicked", self.use_open_drivers)

--- a/vanilla_installer/defaults/theme.py
+++ b/vanilla_installer/defaults/theme.py
@@ -31,6 +31,7 @@ class VanillaDefaultTheme(Gtk.Box):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
 
         self.__build_ui()
 

--- a/vanilla_installer/defaults/timezone.py
+++ b/vanilla_installer/defaults/timezone.py
@@ -86,10 +86,7 @@ class VanillaDefaultTimezone(Adw.Bin):
         self.__key = key
         self.__step = step
         self.__step_num = step["num"]
-
-        self.__expanders = []
-        self.__tz_entries = []
-        self.__generate_timezone_list_widgets()
+        self.delta = True
 
         # signals
         self.btn_next.connect("clicked", self.__window.next)
@@ -97,6 +94,20 @@ class VanillaDefaultTimezone(Adw.Bin):
 
         self.search_controller.connect("key-released", self.__on_search_key_pressed)
         self.entry_search_timezone.add_controller(self.search_controller)
+
+
+    def gen_deltas(self):
+        self.__expanders = []
+        self.__tz_entries = []
+        self.__generate_timezone_list_widgets()
+
+
+    def del_deltas(self):
+        self.__tz_entries = []
+        for i in self.__expanders:
+            self.all_timezones_group.remove(i)
+        self.__expanders = []
+
 
     def timezone_verify(self, carousel=None, idx=None):
         if idx is not None and idx != self.__step_num:

--- a/vanilla_installer/defaults/vm.py
+++ b/vanilla_installer/defaults/vm.py
@@ -33,6 +33,7 @@ class VanillaDefaultVm(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
 
         self.btn_yes.connect("clicked", self.use_vm_tools_fn)
         self.btn_no.connect("clicked", self.skip_vm_tools_fn)

--- a/vanilla_installer/defaults/welcome.py
+++ b/vanilla_installer/defaults/welcome.py
@@ -36,6 +36,7 @@ class VanillaDefaultWelcome(Adw.Bin):
         self.__distro_info = distro_info
         self.__key = key
         self.__step = step
+        self.delta = False
 
         distro_name = self.__distro_info.get("name", "Vanilla OS")
         distro_logo = self.__distro_info.get("logo", "org.vanillaos.Installer-flower")

--- a/vanilla_installer/views/confirm.py
+++ b/vanilla_installer/views/confirm.py
@@ -58,6 +58,7 @@ class VanillaConfirm(Adw.Bin):
 
     def __init__(self, window, **kwargs):
         super().__init__(**kwargs)
+        self.delta = False
 
     def update(self, finals):
         try:

--- a/vanilla_installer/views/done.py
+++ b/vanilla_installer/views/done.py
@@ -35,6 +35,7 @@ class VanillaDone(Adw.Bin):
         super().__init__(**kwargs)
         self.__window = window
         self.__log = None
+        self.delta = False
 
         self.status_page.set_description(
             _("Restart your device to enjoy your {} experience.").format(

--- a/vanilla_installer/views/progress.py
+++ b/vanilla_installer/views/progress.py
@@ -48,6 +48,7 @@ class VanillaProgress(Gtk.Box):
         self.__font.set_weight(Pango.Weight.NORMAL)
         self.__font.set_stretch(Pango.Stretch.NORMAL)
         self.style_manager = Adw.StyleManager().get_default()
+        self.delta = False
 
         self.__build_ui()
         self.__on_setup_terminal_colors()

--- a/vanilla_installer/windows/main_window.py
+++ b/vanilla_installer/windows/main_window.py
@@ -145,6 +145,10 @@ class VanillaWindow(Adw.ApplicationWindow):
         logger.info("Going to next page")
 
         cur_index = self.carousel.get_position()
+        page = self.carousel.get_nth_page(cur_index)
+        if page.delta:
+            logger.info(f"Removing deltas of page {int(cur_index)}")
+            page.del_deltas()
         logger.info(f"Next page is {int(cur_index + 1)}")
 
         if fn is not None:
@@ -154,15 +158,23 @@ class VanillaWindow(Adw.ApplicationWindow):
 
         page = self.carousel.get_nth_page(cur_index + 1)
         self.carousel.scroll_to(page, True)
+        if page.delta:
+            logger.info(f"Generating deltas of page {int(cur_index + 1)}")
+            page.gen_deltas()
 
     def back(self, *args):
         logger.info("Going to previous page")
 
         cur_index = self.carousel.get_position()
+        page = self.carousel.get_nth_page(cur_index)
+        if page.delta:
+            page.del_deltas()
         logger.info(f"Previous page is {int(cur_index - 1)}")
 
         page = self.carousel.get_nth_page(cur_index - 1)
         self.carousel.scroll_to(page, True)
+        if page.delta:
+            page.gen_deltas()
 
     def toast(self, message, timeout=3):
         toast = Adw.Toast.new(message)


### PR DESCRIPTION
First off, if I'm using the wrong term, it's not my fault. It's all Mirko (/j)

This PR improves the performance and almost entirely removes the lag in the installer. The way it does this is by rendering all the pages without the huge lists of the checkboxes for the pages like Language.

Now for the technical explanation:

When the app starts, the builder runs. This runs the entire `__init()` function of each page before the app starts. The rendering of these huge lists of checkboxes - or at least, adding them to GTK's list of widgets - is done before the app even starts. This means that GTK has to take care of 1000+ widgets, most of which aren't always used, and end up causing lagging even on the most basic of pages.

This PR moves the functionality of adding these widget lists to GTK's list to another function, called `gen_deltas()`. This function is run by the main window when the carousel lands on the that page. Note that the page itself is added to the widget list in the `__init()` , only these huge lists of 100+ checkboxes are moved to `gen_deltas()`.

This PR also make adds a new function: `del_deltas()`. This function removes the widget lists from the GTK list when you exit the page. This is called by the main window when the carousel leaves that page.

Or at least, that's what I think happens. In any case, there are performance improvements.

If this PR is merged, hopefully #404 can be merged.