### PR TITLE
fix[#408] custom image field doesn't give hints why the URL is invalid

### DIFF
--- a/vanilla_installer/gtk/default-image.ui
+++ b/vanilla_installer/gtk/default-image.ui
@@ -35,6 +35,7 @@
                     <child>
                       <object class="AdwEntryRow" id="image_url_entry">
                         <property name="title" translatable="yes">URL</property>
+                        <property name="text" translatable="yes">ghcr.io/vanilla-os/desktop:main</property>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Fixes #408 