### PR TITLE
fix [#439]: changes the partition sizes

### DIFF
--- a/vanilla_installer/utils/processor.py
+++ b/vanilla_installer/utils/processor.py
@@ -234,8 +234,8 @@ class Processor:
         setup_steps.append([disk, "setflag", ["2", "esp", True]])
 
         # LVM PVs
-        setup_steps.append([disk, "mkpart", ["vos-root", "none", 1537, 23556]])
-        setup_steps.append([disk, "mkpart", ["vos-var", "none", 23556, -1]])
+        setup_steps.append([disk, "mkpart", ["vos-root", "none", 1537, 23656]])
+        setup_steps.append([disk, "mkpart", ["vos-var", "none", 23656, -1]])
         part_prefix = f"{disk}p" if re.match(r"[0-9]", disk[-1]) else f"{disk}"
         setup_steps.append([disk, "pvcreate", [part_prefix + "3"]])
         setup_steps.append([disk, "pvcreate", [part_prefix + "4"]])
@@ -361,7 +361,8 @@ class Processor:
                 # - 512 MiB from the init LV
                 # - 1024 MiB from the metadata LV
                 # - 1028 MiB from LVM's internals (4 MiB header and 1024 MiB for thin)
-                thin_size = (values["size"] / 1_048_576) - 1024 - 512 - 1028
+                # - 100 MiB to account for various alignment issues
+                thin_size = (values["size"] / 1_048_576) - 1024 - 512 - 1028 - 100
                 setup_steps.append(
                     [part_disk, "lvcreate", ["root-meta", "vos-root", "linear", 1024]]
                 )


### PR DESCRIPTION
LVM would sometimes be missing space due to alignment taking up extra space.

While the 100 MiB are definitely not rigorous I think it's a good balance between taking up unnecessary space and actually fixing this problem for good.

Fixes #439 