### PR TITLE
fix [#440]: set uid of vanilla user

### DIFF
--- a/vanilla_installer/utils/processor.py
+++ b/vanilla_installer/utils/processor.py
@@ -547,6 +547,7 @@ class Processor:
                     "vanilla",
                     ["sudo", "lpadmin"],
                     "vanilla",
+                    1200,
                 ],
                 chroot=True,
                 late=True,


### PR DESCRIPTION
This is to avoid blocking id 1000, since that should go the first user.

Fixes #440 

Requires https://github.com/Vanilla-OS/Albius/pull/87