### PR TITLE
fix[Closes #427]: Only show "Retry connection" button after a failure and skip over connection test page when navigating backwards

### DIFF
--- a/vanilla_installer/defaults/conn_check.py
+++ b/vanilla_installer/defaults/conn_check.py
@@ -99,9 +99,9 @@ class VanillaDefaultConnCheck(Adw.Bin):
                 return
 
             self.status_page.set_icon_name("network-wired-disconnected-symbolic")
-            self.status_page.set_title(_("No Internet Connection!"))
+            self.status_page.set_title(_("No Internet Connection"))
             self.status_page.set_description(
-                _("Installer requires an active internet connection")
+                _("An active internet connection is required to install Vanilla OS")
             )
             self.btn_recheck.set_visible(True)
 
@@ -112,6 +112,6 @@ class VanillaDefaultConnCheck(Adw.Bin):
         self.status_page.set_icon_name("content-loading-symbolic")
         self.status_page.set_title(_("Checking Connection"))
         self.status_page.set_description(
-            _("Please wait until the connection check is done")
+            _("Checking your internet connection, please wait")
         )
         self.__conn_check()

--- a/vanilla_installer/gtk/default-conn-check.ui
+++ b/vanilla_installer/gtk/default-conn-check.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <requires lib="gtk" version="4.0"/>
+    <requires lib="gtk" version="4.0" />
     <requires lib="libadwaita" version="1.0" />
     <template class="VanillaDefaultConnCheck" parent="AdwBin">
         <property name="halign">fill</property>
@@ -10,9 +10,12 @@
             <object class="AdwStatusPage" id="status_page">
                 <property name="icon-name">content-loading-symbolic</property>
                 <property name="title" translatable="yes">Checking Connection</property>
-                <property name="description" translatable="yes">Please wait until the connection check is done</property>
+                <property name="description" translatable="yes">
+                    Checking your internet connection, please wait
+                </property>
                 <child>
                     <object class="GtkButton" id="btn_recheck">
+                        <property name="visible">false</property>
                         <property name="label">Check Again</property>
                         <property name="halign">center</property>
                         <style>

--- a/vanilla_installer/gtk/default-conn-check.ui
+++ b/vanilla_installer/gtk/default-conn-check.ui
@@ -10,13 +10,11 @@
             <object class="AdwStatusPage" id="status_page">
                 <property name="icon-name">content-loading-symbolic</property>
                 <property name="title" translatable="yes">Checking Connection</property>
-                <property name="description" translatable="yes">
-                    Checking your internet connection, please wait
-                </property>
+                <property name="description" translatable="yes">Checking your internet connection, please wait</property>
                 <child>
                     <object class="GtkButton" id="btn_recheck">
                         <property name="visible">false</property>
-                        <property name="label">Check Again</property>
+                        <property name="label">Retry Connection</property>
                         <property name="halign">center</property>
                         <style>
                             <class name="pill" />


### PR DESCRIPTION
Work to do:
- [x] Do not show "Retry connection" button until a failure has occurred
- [x] Edit awkward wording on connection test page (Open to suggestions)
- [ ] Skip over the connection test page when navigating backwards